### PR TITLE
Add filter points

### DIFF
--- a/includes/gateways/class-rcp-payment-gateway-paypal-express.php
+++ b/includes/gateways/class-rcp-payment-gateway-paypal-express.php
@@ -70,7 +70,7 @@ class RCP_Payment_Gateway_PayPal_Express extends RCP_Payment_Gateway {
 			$amount = round( $this->amount + $this->signup_fee, 2 );
 		}
 
-		$args = array(
+		$args = apply_filters( 'paypal_express_request_args', array(
 			'USER'                           => $this->username,
 			'PWD'                            => $this->password,
 			'SIGNATURE'                      => $this->signature,
@@ -95,7 +95,7 @@ class RCP_Payment_Gateway_PayPal_Express extends RCP_Payment_Gateway {
 			'PAGESTYLE'                      => ! empty( $rcp_options['paypal_page_style'] ) ? trim( $rcp_options['paypal_page_style'] ) : '',
 			'SOLUTIONTYPE'                   => 'Sole',
 			'LANDINGPAGE'                    => 'Billing',
-		);
+		) );
 
 		if( $this->auto_renew && ! empty( $this->length ) ) {
 			$args['L_BILLINGAGREEMENTDESCRIPTION0'] = $this->subscription_name;
@@ -317,7 +317,7 @@ class RCP_Payment_Gateway_PayPal_Express extends RCP_Payment_Gateway {
 		} elseif ( ! empty( $_GET['token'] ) && ! empty( $_GET['PayerID'] ) ) {
 
 			add_filter( 'the_content', array( $this, 'confirmation_form' ), 9999999 );
-	
+
 		}
 
 	}

--- a/restrict-content-pro.php
+++ b/restrict-content-pro.php
@@ -58,42 +58,45 @@ function rcp_get_payments_db_name() {
 /*******************************************
 * global variables
 *******************************************/
-global $wpdb;
+function rcp_variable_init(){
+	global $wpdb;
 
-// the plugin base directory
-global $rcp_base_dir; // not used any more, but just in case someone else is
-$rcp_base_dir = dirname( __FILE__ );
+	// the plugin base directory
+	global $rcp_base_dir; // not used any more, but just in case someone else is
+	$rcp_base_dir = dirname( __FILE__ );
 
-// load the plugin options
-$rcp_options = get_option( 'rcp_settings' );
+	// load the plugin options
+	$rcp_options = apply_filters( 'rcp_options_global_variable', get_option( 'rcp_settings' ) );
 
-global $rcp_db_name;
-$rcp_db_name = rcp_get_levels_db_name();
+	global $rcp_db_name;
+	$rcp_db_name = rcp_get_levels_db_name();
 
-global $rcp_db_version;
-$rcp_db_version = '1.5';
+	global $rcp_db_version;
+	$rcp_db_version = '1.5';
 
-global $rcp_discounts_db_name;
-$rcp_discounts_db_name = rcp_get_discounts_db_name();
+	global $rcp_discounts_db_name;
+	$rcp_discounts_db_name = rcp_get_discounts_db_name();
 
-global $rcp_discounts_db_version;
-$rcp_discounts_db_version = '1.2';
+	global $rcp_discounts_db_version;
+	$rcp_discounts_db_version = '1.2';
 
-global $rcp_payments_db_name;
-$rcp_payments_db_name = rcp_get_payments_db_name();
+	global $rcp_payments_db_name;
+	$rcp_payments_db_name = rcp_get_payments_db_name();
 
-global $rcp_payments_db_version;
-$rcp_payments_db_version = '1.4';
+	global $rcp_payments_db_version;
+	$rcp_payments_db_version = '1.4';
 
-/* settings page globals */
-global $rcp_members_page;
-global $rcp_subscriptions_page;
-global $rcp_discounts_page;
-global $rcp_payments_page;
-global $rcp_settings_page;
-global $rcp_reports_page;
-global $rcp_export_page;
-global $rcp_help_page;
+	/* settings page globals */
+	global $rcp_members_page;
+	global $rcp_subscriptions_page;
+	global $rcp_discounts_page;
+	global $rcp_payments_page;
+	global $rcp_settings_page;
+	global $rcp_reports_page;
+	global $rcp_export_page;
+	global $rcp_help_page;
+}
+add_action( 'init', 'rcp_variable_init', 5 );
 
 /*******************************************
 * plugin text domain for translations


### PR DESCRIPTION
Hi Pippin-

I've been exploring whether your plugin will work with a BuddyPress installation, and I think it will. I'm requesting the addition of a few filters specifically so that the `registration_page` option can be handled dynamically. In BP, it makes sense for users to visit their profiles to manage their subscriptions, but that URL is different for each user.

The bigger change is moving the creation of the global variables to WP's `init` hook. I didn't see any actions that occurred earlier in the page load cycle, so I hope that's a safe move. The problem was that if the global variables are assigned as the plugin is loaded, other plugins can't reliably filter those values.

Please let me know if you have any questions.

-David