### PR TITLE
Validate input during discount code creation and updates. #328.

### DIFF
--- a/includes/class-rcp-discounts.php
+++ b/includes/class-rcp-discounts.php
@@ -569,7 +569,7 @@ class RCP_Discounts {
 			return new WP_Error( 'invalid_percent', __( 'Percentage discounts must be whole numbers between 1 and 100.', 'rcp' ) );
 		}
 
-		return filter_input( INPUT_POST, 'amount', FILTER_SANITIZE_NUMBER_FLOAT, FILTER_FLAG_ALLOW_FRACTION  );
+		return filter_var( $amount, FILTER_SANITIZE_NUMBER_FLOAT, FILTER_FLAG_ALLOW_FRACTION  );
 	}
 
 

--- a/includes/class-rcp-discounts.php
+++ b/includes/class-rcp-discounts.php
@@ -290,7 +290,7 @@ class RCP_Discounts {
 		$amount = $this->format_amount( $args['amount'], $args['unit'] );
 
 		if ( is_wp_error( $amount ) ) {
-			wp_die( $amount->get_error_message() );
+			return $amount;
 		} else {
 			$args['amount'] = $amount;
 		}
@@ -353,7 +353,7 @@ class RCP_Discounts {
 		$amount = $this->format_amount( $args['amount'], $args['unit'] );
 
 		if ( is_wp_error( $amount ) ) {
-			wp_die( $amount->get_error_message() );
+			return $amount;
 		} else {
 			$args['amount'] = $amount;
 		}

--- a/includes/process-data.php
+++ b/includes/process-data.php
@@ -270,6 +270,10 @@ function rcp_process_data() {
 
 			$add = $discounts->insert( $data );
 
+			if ( is_wp_error( $add ) ) {
+				wp_die( $add );
+			}
+
 			if( $add ) {
 				$url = get_bloginfo('wpurl') . '/wp-admin/admin.php?page=rcp-discounts&rcp_message=discount_added';
 			} else {
@@ -302,6 +306,10 @@ function rcp_process_data() {
 			);
 
 			$update = $discounts->update( $_POST['discount_id'], $data );
+
+			if ( is_wp_error( $update ) ) {
+				wp_die( $update );
+			}
 
 			if( $update ) {
 				$url = get_bloginfo('wpurl') . '/wp-admin/admin.php?page=rcp-discounts&discount-updated=1';

--- a/tests/test-discounts.php
+++ b/tests/test-discounts.php
@@ -23,6 +23,19 @@ class RCP_Discount_Tests extends WP_UnitTestCase {
 
 	}
 
+	function test_format_amount() {
+		$formatted_amount = $this->db->format_amount( '10', '%' );
+		$this->assertEquals( '10', $formatted_amount );
+	}
+
+	function test_format_amount_decimal() {
+		$formatted_amount = $this->db->format_amount( '10.25', '%' );
+		$this->assertTrue( is_wp_error( $formatted_amount ) );
+
+		$formatted_amount = $this->db->format_amount( '10.25', 'flat' );
+		$this->assertEquals( '10.25', $formatted_amount );
+	}
+
 	function test_has_discounts() {
 		$this->assertTrue( rcp_has_discounts() );
 	}
@@ -33,7 +46,7 @@ class RCP_Discount_Tests extends WP_UnitTestCase {
 			'name'   => 'Test Code 2',
 			'code'   => 'test2',
 			'status' => 'active',
-			'amount' => '10'
+			'amount' => '10',
 		);
 		$discount_id = $this->db->insert( $args );
 
@@ -45,6 +58,7 @@ class RCP_Discount_Tests extends WP_UnitTestCase {
 
 		$updated = $this->db->update( $this->discount_id, array( 'name' => 'Updated Code', 'amount' => '10' ) );
 		$this->assertTrue( $updated );
+
 		$discount = $this->db->get_discount( $this->discount_id );
 		$this->assertEquals( 'Updated Code', $discount->name );
 

--- a/tests/test-discounts.php
+++ b/tests/test-discounts.php
@@ -43,7 +43,7 @@ class RCP_Discount_Tests extends WP_UnitTestCase {
 
 	function test_update_discount() {
 
-		$updated = $this->db->update( $this->discount_id, array( 'name' => 'Updated Code' ) );
+		$updated = $this->db->update( $this->discount_id, array( 'name' => 'Updated Code', 'amount' => '10' ) );
 		$this->assertTrue( $updated );
 		$discount = $this->db->get_discount( $this->discount_id );
 		$this->assertEquals( 'Updated Code', $discount->name );
@@ -136,7 +136,7 @@ class RCP_Discount_Tests extends WP_UnitTestCase {
 	function test_user_has_used() {
 
 		$this->assertFalse( $this->db->user_has_used( 1, 'test' ) );
-		
+
 		$this->db->add_to_user( 1, 'test' );
 
 		$this->assertTrue( $this->db->user_has_used( 1, 'test' ) );


### PR DESCRIPTION
#328.

I need some feedback. I'm not sure about this approach, and I'm not aware of what other things might hook into this.

Stripe doesn't allow percentage discounts with a decimal. For example, you can't use 25.5%.

With that in mind, the PR prevents decimals in percentage discounts. If we need to allow them for other reasons, we'll need to do some gateway detection and/or create a map of allowed discount formats for each gateway.

Things this PR addresses:
- if someone fails to enter a discount amount, it throws a notice and does not create the discount.
- checks that percentage discounts are whole numbers between 1 and 100, based on the comment above, and throws a notice if it doesn't fall within the range 
- ensures the amount entered is a valid number

Since this needs to run in at least two places, I created a helper method for formatting the amount based on the unit type.

Thoughts?