### PR TITLE
Account for letting users resubscribe when they have a previous unpaid subscription in Stripe

### DIFF
--- a/includes/gateways/class-rcp-payment-gateway-stripe.php
+++ b/includes/gateways/class-rcp-payment-gateway-stripe.php
@@ -473,6 +473,23 @@ class RCP_Payment_Gateway_Stripe extends RCP_Payment_Gateway {
 						die( 'no subscription ID for member' );
 					}
 
+					// in case a user attempts to resubscribe but has a previously unpaid subscription
+					if( $event->type == 'customer.subscription.updated' && $payment_event->status == 'unpaid' ) {
+
+						// make sure we're acting on a upgrade or downgrade only
+						if( $event->data->previous_attributes->plan ) {
+
+							// cancel the previous plan
+							$customer = \Stripe\Customer::retrieve( $payment_event->customer );
+							$customer->subscriptions->retrieve( $payment_event->plan->id )->cancel();
+
+							// add the new plan
+							$customer->updateSubscription( array( 'plan' => $payment_event->id ) );
+
+						}
+
+					}
+
 					if( $event->type == 'charge.succeeded' || $event->type == 'invoice.payment_succeeded' ) {
 
 						// setup payment data

--- a/includes/gateways/class-rcp-payment-gateway-stripe.php
+++ b/includes/gateways/class-rcp-payment-gateway-stripe.php
@@ -129,11 +129,7 @@ class RCP_Payment_Gateway_Stripe extends RCP_Payment_Gateway {
 				// Add fees before the plan is updated and charged
 				if ( ! empty( $this->signup_fee ) ) {
 
-					if( $this->signup_fee > 0 ) {
-						$customer->account_balance = $customer->account_balance - ( $this->signup_fee * 100 ); // Add additional amount to initial payment (in cents)
-					} else if( $this->signup_fee < 0 ) {
-						$customer->account_balance = $customer->account_balance + ( $this->signup_fee * 100 ); // Add additional amount to initial payment (in cents)
-					}
+					$customer->account_balance = $customer->account_balance + ( $this->signup_fee * 100 ); // Add additional amount to initial payment (in cents)	
 
 				}
 

--- a/includes/gateways/class-rcp-payment-gateway-stripe.php
+++ b/includes/gateways/class-rcp-payment-gateway-stripe.php
@@ -488,23 +488,6 @@ class RCP_Payment_Gateway_Stripe extends RCP_Payment_Gateway {
 						die( 'no subscription ID for member' );
 					}
 
-					// in case a user attempts to resubscribe but has a previously unpaid subscription
-					if( $event->type == 'customer.subscription.updated' && $payment_event->status == 'unpaid' ) {
-
-						// make sure we're acting on a upgrade or downgrade only
-						if( $event->data->previous_attributes->plan ) {
-
-							// cancel the previous plan
-							$customer = \Stripe\Customer::retrieve( $payment_event->customer );
-							$customer->subscriptions->retrieve( $payment_event->id )->cancel();
-
-							// add the new subscription plan
-							$customer->subscriptions->create( array( 'plan' => $payment_event->plan->id ) );
-
-						}
-
-					}
-
 					if( $event->type == 'charge.succeeded' || $event->type == 'invoice.payment_succeeded' ) {
 
 						// setup payment data

--- a/restrict-content-pro.php
+++ b/restrict-content-pro.php
@@ -3,7 +3,7 @@
 Plugin Name: Restrict Content Pro
 Plugin URL: http://pippinsplugins.com/restrict-content-pro-premium-content-plugin
 Description: Set up a complete subscription system for your WordPress site and deliver premium content to your subscribers. Unlimited subscription packages, membership management, discount codes, registration / login forms, and more.
-Version: 2.4.9
+Version: 2.4.10
 Author: Pippin Williamson
 Author URI: http://pippinsplugins.com
 Contributors: mordauk
@@ -21,7 +21,7 @@ if ( !defined( 'RCP_PLUGIN_FILE' ) ) {
 	define( 'RCP_PLUGIN_FILE', __FILE__ );
 }
 if ( !defined( 'RCP_PLUGIN_VERSION' ) ) {
-	define( 'RCP_PLUGIN_VERSION', '2.4.9' );
+	define( 'RCP_PLUGIN_VERSION', '2.4.10' );
 }
 
 


### PR DESCRIPTION
This PR fixes #302, whereby a user with a previous, `unpaid` subscription was blocked for signing up again to a new plan. 

The route I've taken works, but it may not be ideal. 

If a user has an `unpaid` subscription then we first cancel that old one and then subscribe them fresh to the new subscription. This works. The problem, though, is that it does not get counted as a *Upgrade* subscription, even though they're technically changing plans. I'm not sure if this is a good thing or a bad thing.

For example, here is the event log for the test user that I used: 
![screen shot 2016-02-08 at 5 57 47 pm](https://cloud.githubusercontent.com/assets/1648631/12903484/89b302e6-ce8d-11e5-98d5-a6450412fd12.png)
