### PR TITLE
Add PHP nightly and composer self-update to Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,13 +8,34 @@ php:
     - 5.5
     - 5.6
     - 7
+    - nightly
     - hhvm
 
 env:
     - WP_VERSION=latest WP_MULTISITE=0
     - WP_VERSION=latest WP_MULTISITE=1
+    - WP_VERSION=4.4 WP_MULTISITE=0
+    - WP_VERSION=4.4 WP_MULTISITE=1
     - WP_VERSION=4.3 WP_MULTISITE=0
     - WP_VERSION=4.3 WP_MULTISITE=1
+    - WP_VERSION=4.2 WP_MULTISITE=0
+    - WP_VERSION=4.1 WP_MULTISITE=0
+    - WP_VERSION=4.0 WP_MULTISITE=0
+
+matrix:
+  include:
+    - php: 7.0
+      env: WP_VERSION=trunk
+  exclude:
+    - php: hhvm
+      env: WP_VERSION=4.0 WP_MULTISITE=0
+  allow_failures:
+    - php: 7.0 
+    - php: nightly
+
+install:
+    - composer self-update && composer --version
+    - export PATH="$HOME/.composer/vendor/bin:$PATH"
 
 before_script:
     - bash bin/install-wp-tests.sh wordpress_test root '' localhost $WP_VERSION 


### PR DESCRIPTION
- Added WordPress 4.4 single and multisite builds
- Added WordPress 4.3 multisite build
- Added WordPress 4.2, 4.1, and 4.0 single install builds
- Added matrix to include WordPress trunk on PHP 7, exclude WordPress 4.0 from HHVM, and allow failures for PHP 7 and nightly