### PR TITLE
Return non-formatted amount in calc_discounted_price(). #602

### DIFF
--- a/includes/class-rcp-discounts.php
+++ b/includes/class-rcp-discounts.php
@@ -539,7 +539,7 @@ class RCP_Discounts {
 			$discounted_price = $base_price - $discount_amount;
 		}
 
-		return number_format( (float) $discounted_price, 2 );
+		return $discounted_price;
 
 	}
 

--- a/tests/test-discounts.php
+++ b/tests/test-discounts.php
@@ -170,5 +170,17 @@ class RCP_Discount_Tests extends WP_UnitTestCase {
 		$this->assertEquals( 90, $this->db->calc_discounted_price( 100, 10, 'flat' ) );
 	}
 
+	function test_calc_discounted_price_with_high_price_and_flat_discount() {
+
+		$this->assertEquals( 1979, $this->db->calc_discounted_price( 1999, 20, 'flat' ) );
+
+	}
+
+	function test_calc_discounted_price_with_high_price_and_percentage_discount() {
+
+		$this->assertEquals( 1599.2, $this->db->calc_discounted_price( 1999, 20, '%' ) );
+
+	}
+
 }
 


### PR DESCRIPTION
Do not format the amount returned by calc_discounted_price(). #602 