### PR TITLE
Invoice improvements

### DIFF
--- a/templates/invoice.php
+++ b/templates/invoice.php
@@ -223,7 +223,7 @@
 					<?php if ( ! empty( $rcp_options['invoice_email'] ) ) : ?>
 						<p><strong><?php echo $rcp_options['invoice_email']; ?></strong></p>
 					<?php endif; ?>
-
+					<?php do_action( 'rcp_invoice_extra' ); ?>
 				</article>
 			</div>
 
@@ -234,6 +234,7 @@
 				<article>
 					<p><strong><?php echo $rcp_member->first_name . ' ' . $rcp_member->last_name; ?></strong></p>
 					<p><strong><?php echo $rcp_member->user_email; ?></strong></p>
+					<?php do_action( 'rcp_member_invoice_fields', $rcp_payment ); ?>
 				</article>
 
 			</div>
@@ -248,18 +249,21 @@
 				<tbody>
 					<tr>
 						<td class="name"><?php echo $rcp_payment->subscription; ?></td>
+						<?php do_action( 'rcp_member_invoice_row_fields', $rcp_payment ); ?>
 						<td class="price"><?php echo rcp_currency_filter( $rcp_payment->amount ); ?></td>
 					</tr>
 				</tbody>
 				<tfoot>
 					<!-- Total -->
 					<tr>
+						<?php do_action( 'rcp_member_invoice_total_fields', $rcp_payment ); ?>
 						<td class="name"><?php _e( 'Total Price:', 'rcp' ); ?></td>
 						<td class="price"><?php echo rcp_currency_filter( $rcp_payment->amount ); ?></td>
 					</tr>
 
 					<!-- Paid -->
 					<tr>
+						<?php do_action( 'rcp_member_invoice_status_fields', $rcp_payment ); ?>
 						<td class="name"><?php _e( 'Payment Status:', 'rcp' ); ?></td>
 						<td class="price"><?php echo rcp_get_payment_status_label( $rcp_payment ); ?></td>
 					</tr>

--- a/templates/invoice.php
+++ b/templates/invoice.php
@@ -169,6 +169,9 @@
 		margin: 60px 0 0 0;
 		text-align: right;
 	}
+	img {
+		max-width: 100%;
+	}
 	@media print  {
 		.print {
 			display: none;


### PR DESCRIPTION
Two changes:

1. The header logo on my invoices was looking too big and getting cut off. This adds a CSS directive to all `img` tags to keep them within the bounds.

2. Add hooks for customizing the invoice information displayed. I personally use these to add information such as the member's business name and address, VAT ID, and VAT %, all of which are required for Europe.