### PR TITLE
Make sure logo doesn't get too big on invoice

### DIFF
--- a/templates/invoice.php
+++ b/templates/invoice.php
@@ -169,6 +169,9 @@
 		margin: 60px 0 0 0;
 		text-align: right;
 	}
+	img {
+		max-width: 100%;
+	}
 	@media print  {
 		.print {
 			display: none;


### PR DESCRIPTION
The logo on my site was spilling out of the `div`. This makes sure it never gets bigger than the `div` it is contained in.