### PR TITLE
Set expected format in the input of user's expiration date. #704

### DIFF
--- a/includes/admin/members/edit-member.php
+++ b/includes/admin/members/edit-member.php
@@ -64,7 +64,13 @@ $member = new RCP_Member( $member_id );
 					<label for="rcp-expiration"><?php _e( 'Expiration date', 'rcp' ); ?></label>
 				</th>
 				<td>
-					<input name="expiration" id="rcp-expiration" type="text" style="width: 120px;" class="rcp-datepicker" value="<?php echo esc_attr( $member->get_expiration_date() ); ?>"/>
+					<?php
+					$expiration_date = $member->get_expiration_date( false );
+					if( 'none' != $expiration_date ) {
+						$expiration_date = date( 'Y-m-d', strtotime( $expiration_date, current_time( 'timestamp' ) ) );
+					}
+					?>
+					<input name="expiration" id="rcp-expiration" type="text" style="width: 120px;" class="rcp-datepicker" value="<?php echo esc_attr( $expiration_date ); ?>"/>
 					<label for="rcp-unlimited">
 						<input name="unlimited" id="rcp-unlimited" type="checkbox"<?php checked( get_user_meta( $member->ID, 'rcp_expiration', true ), 'none' ); ?>/>
 						<span class="description"><?php _e( 'Never expires?', 'rcp' ); ?></span>


### PR DESCRIPTION
#710 was not working because the textual date is in a foreign language (French for me, Spanish for @boluda) so not accepted by the [date function format](http://php.net/manual/en/datetime.formats.date.php). And, as the inverse function of [date_i18n](https://codex.wordpress.org/Function_Reference/date_i18n) does not seem to exist, this change puts directly the format expected by the from processor in the input. So when I validate without editing this field, it is not reinitialized to 1 Jan. 1970. Moreover, the datepicker works fine: already setting the content of the input field to `Y-m-d` format.

*Before that, I had to set it to the right format (i.e. 2016-10-16) manually or selecting the date with the datepicker before submitting the form, otherwise the date was set to 1 Jan. 1970. See #704.*