### PR TITLE
Fix not showing again reinit password form when error in this form. #354

### DIFF
--- a/includes/member-forms.php
+++ b/includes/member-forms.php
@@ -22,7 +22,7 @@ function rcp_login_form_fields( $args = array() ) {
 		echo rcp_lostpassword_form_fields();
 	} elseif ( isset($_REQUEST['rcp_action']) && $_REQUEST['rcp_action'] === "lostpassword_checkemail") {
 		echo rcp_lostpassword_checkemail_message();
-	} elseif ( isset($_REQUEST['rcp_action']) && $_REQUEST['rcp_action'] === "lostpassword_reset") {
+	} elseif ( isset($_REQUEST['rcp_action']) && ( $_REQUEST['rcp_action'] === "lostpassword_reset" || $_REQUEST['rcp_action'] === "reset-password" )) {
 		echo rcp_change_password_form();
 	} else {
 		do_action( 'rcp_before_login_form' );


### PR DESCRIPTION
When the user clicks on the link of the login form to reset his password then clicks on the link in the email he received to set a new password, he reaches the reinit password form. 
If everything is fine when he enters his new password, he is redirected properly to the login form and can log in. However, if he put nothing in the reinit password form or if the two password fields do not match, the same occurs : he is redirected to the login form (without error message !) whereas the password was not changed. So I receive complaints from people who think they have changed their password (whereas they mistook in the form) but cannot login because the password was not actually reset...

This fix from @thomasfw in #354 changes the behavior if the user mistakes : the reinit password form is shown again with the proper error message so the user knows he mistook and has to enter again the new password.