### PR TITLE
Fix fatal error on unsupported PHP versions

### DIFF
--- a/restrict-content-pro.php
+++ b/restrict-content-pro.php
@@ -260,6 +260,9 @@ if( version_compare( PHP_VERSION, '5.3', '<' ) ) {
 		include( RCP_PLUGIN_DIR . 'includes/query-filters.php' );
 		include( RCP_PLUGIN_DIR . 'includes/redirects.php' );
 	}
+	
+	// Set up database classes.
+	add_action( 'plugins_loaded', 'rcp_register_databases', 11 );
 
 }
 
@@ -282,4 +285,3 @@ function rcp_register_databases() {
 	$wpdb->paymentmeta = $rcp_payments_db->meta_db_name;
 
 }
-add_action( 'plugins_loaded', 'rcp_register_databases', 11 );


### PR DESCRIPTION
If someone's PHP version is lower than 5.3, none of the plugin files get loaded, but the `rcp_register_databases` action still triggers. This causes a fatal error when trying to use classes (like `RCP_Payments`) that don't exist.

Moving the action into the `else` block for the version check fixes the problem.