### PR TITLE
Cookie name filter

### DIFF
--- a/includes/login-functions.php
+++ b/includes/login-functions.php
@@ -149,7 +149,7 @@ function rcp_process_lostpassword_reset() {
 	nocache_headers();
 
 	list( $rp_path ) = explode( '?', wp_unslash( $_SERVER['REQUEST_URI'] ) );
-	$rp_cookie = 'rcp-resetpass-' . COOKIEHASH;
+	$rp_cookie = apply_filters( 'rcp_resetpass_cookie_name', 'rcp-resetpass-' . COOKIEHASH );
 
 	// store reset key and login name in cookie & remove from URL
 	if ( isset( $_GET['key'] ) ) {

--- a/includes/member-functions.php
+++ b/includes/member-functions.php
@@ -833,7 +833,7 @@ function rcp_change_password() {
 		global $user_ID;
 
 		list( $rp_path ) = explode( '?', wp_unslash( $_SERVER['REQUEST_URI'] ) );
-		$rp_cookie = 'rcp-resetpass-' . COOKIEHASH;
+		$rp_cookie = apply_filters( 'rcp_resetpass_cookie_name', 'rcp-resetpass-' . COOKIEHASH );
 
 		$user = rcp_get_user_resetting_password( $rp_cookie );
 


### PR DESCRIPTION
Pantheon requires cookies that need to get back to the server to be prefixed. If you add a filter here, it would allow developers the ability to change the cookie name to allow the cookie to bypass caching filters. Docs: https://pantheon.io/docs/cookies/