### PR TITLE
Adding email to admin cancellation notification

### DIFF
--- a/includes/email-functions.php
+++ b/includes/email-functions.php
@@ -66,7 +66,7 @@ function rcp_email_subscription_status( $user_id, $status = 'active' ) {
 			}
 
 			if( ! isset( $rcp_options['disable_new_user_notices'] ) ) {
-				$admin_message = __('Hello', 'rcp') . "\n\n" . $user_info->display_name .  ' (' . $user_info->user_login . ') ' . __('has cancelled their subscription to', 'rcp') . ' ' . $site_name . ".\n\n" . __('Their subscription level was', 'rcp') . ': ' . rcp_get_subscription($user_id) . "\n\n";
+				$admin_message = __('Hello', 'rcp') . "\n\n" . $user_info->display_name .  ' (' . $user_info->user_login . ' - ' . $user_info->user_email . ') ' . __('has cancelled their subscription to', 'rcp') . ' ' . $site_name . ".\n\n" . __('Their subscription level was', 'rcp') . ': ' . rcp_get_subscription($user_id) . "\n\n";
 				$admin_message = apply_filters('rcp_before_admin_email_cancelled_thanks', $admin_message, $user_id);
 				$admin_message .= __('Thank you', 'rcp');
 				wp_mail( $admin_emails, __('Cancelled subscription on ', 'rcp') . $site_name, $admin_message, $headers, $attachments );

--- a/restrict-content-pro.php
+++ b/restrict-content-pro.php
@@ -3,7 +3,7 @@
 Plugin Name: Restrict Content Pro
 Plugin URL: https://restrictcontentpro.com
 Description: Set up a complete subscription system for your WordPress site and deliver premium content to your subscribers. Unlimited subscription packages, membership management, discount codes, registration / login forms, and more.
-Version: 2.6.15
+Version: 2.6.16
 Author: Restrict Content Pro Team
 Author URI: https://restrictcontentpro.com
 Contributors: mordauk
@@ -21,7 +21,7 @@ if ( !defined( 'RCP_PLUGIN_FILE' ) ) {
 	define( 'RCP_PLUGIN_FILE', __FILE__ );
 }
 if ( !defined( 'RCP_PLUGIN_VERSION' ) ) {
-	define( 'RCP_PLUGIN_VERSION', '2.6.15' );
+	define( 'RCP_PLUGIN_VERSION', '2.6.16' );
 }
 if ( ! defined( 'CAL_GREGORIAN' ) ) {
 	define( 'CAL_GREGORIAN', 1 );


### PR DESCRIPTION
This improves the email by allowing admins to have the email to directly reply to folks after they cancel. Otherwise, you have to log into the admin and find the users email before you can email them directly. This commit adds the email to eliminate that extra step. 

I'm aware that you can have RCP send an email upon cancellation and I've been doing so, but I've found that sometimes I need to follow up with these folks for other reasons. Having direct access to their email via the cancellation email would help this workflow a lot. 