### PR TITLE
Pass $event to rcp_stripe_charge_succeeded hook

### DIFF
--- a/includes/gateways/class-rcp-payment-gateway-stripe.php
+++ b/includes/gateways/class-rcp-payment-gateway-stripe.php
@@ -544,8 +544,8 @@ class RCP_Payment_Gateway_Stripe extends RCP_Payment_Gateway {
 					// failed payment
 					if ( $event->type == 'charge.failed' ) {
 
-						do_action( 'rcp_recurring_payment_failed', $member, $this );
-						do_action( 'rcp_stripe_charge_failed', $invoice );
+						do_action( 'rcp_recurring_payment_failed', $member, $this, $event );
+						do_action( 'rcp_stripe_charge_failed', $payment_event, $event );
 
 						die( 'rcp_stripe_charge_failed action fired successfully' );
 
@@ -564,7 +564,7 @@ class RCP_Payment_Gateway_Stripe extends RCP_Payment_Gateway {
 
 					}
 
-					do_action( 'rcp_stripe_' . $event->type, $payment_event );
+					do_action( 'rcp_stripe_' . $event->type, $payment_event, $event );
 
 				}
 

--- a/includes/gateways/class-rcp-payment-gateway-stripe.php
+++ b/includes/gateways/class-rcp-payment-gateway-stripe.php
@@ -529,7 +529,7 @@ class RCP_Payment_Gateway_Stripe extends RCP_Payment_Gateway {
 								$rcp_payments->insert( $payment_data );
 							}
 
-							do_action( 'rcp_stripe_charge_succeeded', $user, $payment_data );
+							do_action( 'rcp_stripe_charge_succeeded', $user, $payment_data, $event );
 
 							die( 'rcp_stripe_charge_succeeded action fired successfully' );
 


### PR DESCRIPTION
I don't _think_ there's any downside to this, it should be fully backwards compatible, and it allows for using the stripe event data to inform what actions an extension might want to take. Probably a bit of an edge case in terms of usefulness, but it'd be handy for something I'm working on right now.