### PR TITLE
Apply discount to signup fee. #848

### DIFF
--- a/includes/class-rcp-registration.php
+++ b/includes/class-rcp-registration.php
@@ -302,9 +302,9 @@ class RCP_Registration {
 		}
 
 		// make sure the discount is not > 100%
-		if ( 0 > $total ) {
-			$total = 0;
-		}
+		// if ( 0 > $total ) {
+		// 	$total = 0;
+		// }
 
 		return apply_filters( 'rcp_registration_get_total_discounts', (float) ( $original_total - $total ), $original_total, $only_recurring, $this );
 
@@ -322,7 +322,8 @@ class RCP_Registration {
 	public function get_total( $discounts = true, $fees = true ) {
 
 		$total = rcp_get_subscription_price( $this->subscription );
-
+		// Used for tracking discount above total subscription price.
+		$leftover = 0;
 		if ( $fees ) {
 			$total += $this->get_proration_credits();
 		}
@@ -332,6 +333,8 @@ class RCP_Registration {
 		}
 
 		if ( 0 > $total ) {
+			// Take the additional above the subscription and save it for later.
+			$leftover = $total * -1;
 			$total = 0;
 		}
 
@@ -339,6 +342,10 @@ class RCP_Registration {
 			$total += $this->get_signup_fees( $total );
 		}
 
+		// If the total is above 0 and there's leftover, use it.
+		if ( 0 < $total && 0 < $leftover ) {
+			$total -= $leftover;
+		}
 		if ( 0 > $total ) {
 			$total = 0;
 		}

--- a/includes/registration-functions.php
+++ b/includes/registration-functions.php
@@ -709,7 +709,9 @@ function rcp_registration_total( $echo = true ) {
 	$trial_duration_unit = $rcp_levels_db->trial_duration_unit( $level->id );
 
 	if ( ! empty( $trial_duration ) && ! rcp_has_used_trial() ) {
+		$total_price = $total;
 		$total = sprintf( __( 'Free trial - %s', 'rcp' ), $trial_duration . ' ' .  rcp_filter_duration_unit( $trial_duration_unit, $trial_duration ) );
+		$total .= ', ' . $total_price . ' due after trial period.';
 	}
 
 	$total = apply_filters( 'rcp_registration_total', $total );

--- a/templates/register-total-details.php
+++ b/templates/register-total-details.php
@@ -40,14 +40,6 @@ if ( ! rcp_is_registration() ) {
 					<th colspan="2"><?php _e( 'Discounts and Fees', 'rcp' ); ?></th>
 				</tr>
 
-				<?php // Discounts ?>
-				<?php if ( rcp_get_registration()->get_discounts() ) : foreach( rcp_get_registration()->get_discounts() as $code => $recuring ) : if ( ! $discount = rcp_get_discount_details_by_code( $code ) ) continue; ?>
-					<tr class="rcp-discount">
-						<td data-th="<?php esc_attr_e( 'Discount', 'rcp' ); ?>"><?php echo esc_html( $discount->name ); ?></td>
-						<td data-th="<?php esc_attr_e( 'Discount Amount', 'rcp' ); ?>"><?php echo esc_html( rcp_discount_sign_filter( $discount->amount, $discount->unit ) ); ?></td>
-					</tr>
-				<?php endforeach; endif; ?>
-
 				<?php // Fees ?>
 				<?php if ( rcp_get_registration()->get_fees() ) : foreach( rcp_get_registration()->get_fees() as $fee ) :
 
@@ -58,6 +50,14 @@ if ( ! rcp_is_registration() ) {
 					<tr class="rcp-fee">
 						<td data-th="<?php esc_attr_e( 'Fee', 'rcp' ); ?>"><?php echo esc_html( $fee['description'] ); ?></td>
 						<td data-th="<?php esc_attr_e( 'Fee Amount', 'rcp' ); ?>"><?php echo esc_html( $sign . rcp_currency_filter( $fee['amount'] ) ); ?></td>
+					</tr>
+				<?php endforeach; endif; ?>
+
+				<?php // Discounts ?>
+				<?php if ( rcp_get_registration()->get_discounts() ) : foreach( rcp_get_registration()->get_discounts() as $code => $recuring ) : if ( ! $discount = rcp_get_discount_details_by_code( $code ) ) continue; ?>
+					<tr class="rcp-discount">
+						<td data-th="<?php esc_attr_e( 'Discount', 'rcp' ); ?>"><?php echo esc_html( $discount->name ); ?></td>
+						<td data-th="<?php esc_attr_e( 'Discount Amount', 'rcp' ); ?>"><?php echo esc_html( rcp_discount_sign_filter( $discount->amount, $discount->unit ) ); ?></td>
 					</tr>
 				<?php endforeach; endif; ?>
 


### PR DESCRIPTION
#848 reads,
> Got a requested for this. Currently discounts are applied to the subscription price but not signup fees. This was suggested as an extra settings option.

I’m sure I’m oversimplifying this, but I thought I would submit a PR to get the ball rolling. The premise here is to use anything leftover from the discount to apply to the signup fee.

If this is the right direction and generally accepted for further development and testing, I anticipate adding a field to discounts to use the old vs new functionality. 