### PR TITLE
Bump composer/installers version #1284

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,6 +12,6 @@
 		}
 	],
 	"require": {
-		"composer/installers": "~1.3.0"
+		"composer/installers": "~1.0"
 	}
 }


### PR DESCRIPTION
Current composer/installers version number in composer.json causes version conflict when used with Bedrock. Increased to v1.3.0 for compatibility.