### PR TITLE
Don't override join date during registration if it's already set #1286

### DIFF
--- a/includes/class-rcp-member.php
+++ b/includes/class-rcp-member.php
@@ -289,9 +289,10 @@ class RCP_Member extends WP_User {
 		}
 
 		// check if joined date already exists.
-		$has_joined_date = ! empty( get_user_meta( $this->ID, 'rcp_joined_date_' . $this->get_subscription_id(), true ) );
+		$joined_date = get_user_meta( $this->ID, 'rcp_joined_date_' . $this->get_subscription_id(), true );
+		$has_joined_date = ! empty( $joined_date );
 
-		// only update rcp_joined_date if the user meta doesn't exist
+		// only update rcp_joined_date if the user meta doesn't exist.
 		$ret = $has_joined_date || update_user_meta( $this->ID, 'rcp_joined_date_' . $this->get_subscription_id(), $date );
 
 		do_action( 'rcp_set_joined_date', $this->ID, $date, $this );

--- a/includes/class-rcp-member.php
+++ b/includes/class-rcp-member.php
@@ -288,7 +288,11 @@ class RCP_Member extends WP_User {
 			$subscription_id = $this->get_subscription_id();
 		}
 
-		$ret = update_user_meta( $this->ID, 'rcp_joined_date_' . $this->get_subscription_id(), $date );
+		// check if joined date already exists.
+		$has_joined_date = ! empty( get_user_meta( $this->ID, 'rcp_joined_date_' . $this->get_subscription_id(), true ) );
+
+		// only update rcp_joined_date if the user meta doesn't exist
+		$ret = $has_joined_date || update_user_meta( $this->ID, 'rcp_joined_date_' . $this->get_subscription_id(), $date );
 
 		do_action( 'rcp_set_joined_date', $this->ID, $date, $this );
 


### PR DESCRIPTION
Fixes #1286.

Basically, first I check if the joined_date for that subscription ID already exists, if it exists I don't update the date.

I only have 2 questions:
- If the joined_date for that subscription already exists I'm returning true. Should I return false instead?
- Also, if the joined_date already exists I'm still calling the action rcp_set_joined_date. Should I leave it?