### PR TITLE
Make post-verification redirect filterable

### DIFF
--- a/includes/member-functions.php
+++ b/includes/member-functions.php
@@ -1400,7 +1400,7 @@ function rcp_confirm_email_verification() {
 		return;
 	}
 
-	wp_safe_redirect( apply_filters( 'rcp_verification_redirect_url', $redirect, $user->ID ) );
+	wp_safe_redirect( apply_filters( 'rcp_verification_redirect_url', $redirect, $member ) );
 	exit;
 
 }

--- a/includes/member-functions.php
+++ b/includes/member-functions.php
@@ -1400,7 +1400,7 @@ function rcp_confirm_email_verification() {
 		return;
 	}
 
-	wp_safe_redirect( $redirect );
+	wp_safe_redirect( apply_filters( 'rcp_verification_redirect', $redirect, $user->ID ) );
 	exit;
 
 }

--- a/includes/member-functions.php
+++ b/includes/member-functions.php
@@ -1400,7 +1400,7 @@ function rcp_confirm_email_verification() {
 		return;
 	}
 
-	wp_safe_redirect( apply_filters( 'rcp_verification_redirect', $redirect, $user->ID ) );
+	wp_safe_redirect( apply_filters( 'rcp_verification_redirect_url', $redirect, $user->ID ) );
 	exit;
 
 }


### PR DESCRIPTION
Adds a new filter, `rcp_verification_redirect_url`, allowing users to redirect to an arbitary URL after clicking an email verification link.

Fixes #1414.