### PR TITLE
Actions for custom fields in signle payment admin page. #1449

### DIFF
--- a/includes/admin/payments/edit-payment.php
+++ b/includes/admin/payments/edit-payment.php
@@ -27,7 +27,7 @@ $subscription = rcp_get_subscription_details( $payment->object_id );
 <form id="rcp-edit-payment" action="" method="post">
 	<table class="form-table">
 		<tbody>
-		<?php do_action( 'rcp_edit_payment_before', $payment_id, $payment, $subscription ); ?>
+		<?php do_action( 'rcp_edit_payment_before', $payment, $subscription, $user ); ?>
 		<tr valign="top">
 			<th scope="row" valign="top">
 				<label for="rcp-user-id"><?php _e( 'User', 'rcp' ); ?></label>
@@ -124,7 +124,7 @@ $subscription = rcp_get_subscription_details( $payment->object_id );
 				<a href="<?php echo esc_url( rcp_get_invoice_url( $payment_id ) ); ?>" class="button-secondary" target="_blank"><?php _e( 'View Invoice', 'rcp' ); ?></a>
 			</td>
 		</tr>
-		<?php do_action( 'rcp_edit_payment_after', $payment_id, $payment, $subscription ); ?>
+		<?php do_action( 'rcp_edit_payment_after', $payment, $subscription, $user ); ?>
 		</tbody>
 	</table>
 	<p class="submit">

--- a/includes/admin/payments/edit-payment.php
+++ b/includes/admin/payments/edit-payment.php
@@ -27,6 +27,7 @@ $subscription = rcp_get_subscription_details( $payment->object_id );
 <form id="rcp-edit-payment" action="" method="post">
 	<table class="form-table">
 		<tbody>
+		<?php do_action( 'rcp_edit_payment_before', $payment_id, $payment, $subscription ); ?>
 		<tr valign="top">
 			<th scope="row" valign="top">
 				<label for="rcp-user-id"><?php _e( 'User', 'rcp' ); ?></label>
@@ -123,6 +124,7 @@ $subscription = rcp_get_subscription_details( $payment->object_id );
 				<a href="<?php echo esc_url( rcp_get_invoice_url( $payment_id ) ); ?>" class="button-secondary" target="_blank"><?php _e( 'View Invoice', 'rcp' ); ?></a>
 			</td>
 		</tr>
+		<?php do_action( 'rcp_edit_payment_after', $payment_id, $payment, $subscription ); ?>
 		</tbody>
 	</table>
 	<p class="submit">

--- a/includes/admin/payments/new-payment.php
+++ b/includes/admin/payments/new-payment.php
@@ -18,6 +18,7 @@
 <form id="rcp-add-payment" action="" method="post">
 	<table class="form-table">
 		<tbody>
+			<?php do_action( 'rcp_add_payment_before' ); ?>
 			<tr valign="top">
 				<th scope="row" valign="top">
 					<label for="rcp-user-id"><?php _e( 'User', 'rcp' ); ?></label>
@@ -71,6 +72,7 @@
 					<p class="description"><?php _e( 'The status of this payment.', 'rcp' ); ?></p>
 				</td>
 			</tr>
+			<?php do_action( 'rcp_add_payment_after' ); ?>
 		</tbody>
 	</table>
 	<p class="submit">


### PR DESCRIPTION
Added following actions:

`rcp_add_payment_before`
`rcp_add_payment_after`

`rcp_edit_payment_before`
`rcp_edit_payment_after`

Allow third-party plugins to print custom meta fields in new payment and edit payment pages.

Related to #1449.