### PR TITLE
Add rcp_create_tables hook

### DIFF
--- a/includes/install.php
+++ b/includes/install.php
@@ -304,4 +304,6 @@ function rcp_create_tables() {
 		) CHARACTER SET utf8 COLLATE utf8_general_ci;";
 
 	@dbDelta( $sql );
+	
+	do_action( 'rcp_create_tables' );
 }

--- a/includes/install.php
+++ b/includes/install.php
@@ -175,6 +175,7 @@ function rcp_options_install( $network_wide = false ) {
 	update_option( 'rcp_is_installed', '1' );
 	update_option( 'rcp_version', RCP_PLUGIN_VERSION );
 
+	do_action( 'rcp_options_install' );
 }
 // run the install scripts upon plugin activation
 register_activation_hook( RCP_PLUGIN_FILE, 'rcp_options_install' );


### PR DESCRIPTION
Closes https://github.com/restrictcontentpro/restrict-content-pro/issues/1486

I tried to follow what appear to be existing naming patterns for hooks in RCP; obviously it's fine if a different name is used.