### PR TITLE
Fix customized fields can't be updated in member edit action. #1691

### DIFF
--- a/includes/admin/members/member-actions.php
+++ b/includes/admin/members/member-actions.php
@@ -119,7 +119,7 @@ function rcp_process_edit_member() {
 		wp_update_user( array( 'ID' => $user_id, 'user_email' => $email ) );
 	}
 
-	do_action( 'rcp_edit_member', $user_id );
+	do_action( 'rcp_edit_member', $user_id , $_POST );
 
 	rcp_log( sprintf( '%s finished editing member #%d.', $current_user->user_login, $user_id ) );
 


### PR DESCRIPTION
add $_POST after do_action rcp_edit_member for updating customized user meta (Fix customized field can't be updated in member edit action)