### PR TITLE
Do not set sslverify to false

### DIFF
--- a/RCP_Plugin_Updater.php
+++ b/RCP_Plugin_Updater.php
@@ -300,21 +300,6 @@ class RCP_Plugin_Updater {
 	}
 
 	/**
-	 * Disable SSL verification in order to prevent download update failures
-	 *
-	 * @param array   $args
-	 * @param string  $url
-	 * @return object $array
-	 */
-	public function http_request_args( $args, $url ) {
-		// If it is an https request and we are performing a package download, disable ssl verification
-		if ( strpos( $url, 'https://' ) !== false && strpos( $url, 'edd_action=package_download' ) ) {
-			$args['sslverify'] = false;
-		}
-		return $args;
-	}
-
-	/**
 	 * Calls the API and, if successfull, returns the object delivered by the API.
 	 *
 	 * @uses get_bloginfo()
@@ -351,7 +336,10 @@ class RCP_Plugin_Updater {
 			'beta'       => ! empty( $data['beta'] ),
 		);
 
-		$request = wp_remote_post( $this->api_url, array( 'timeout' => 15, 'sslverify' => false, 'body' => $api_params ) );
+		$request = wp_remote_post( $this->api_url, array(
+			'timeout' => 15,
+			'body'    => $api_params
+		) );
 
 		if ( ! is_wp_error( $request ) ) {
 			$request = json_decode( wp_remote_retrieve_body( $request ) );
@@ -413,7 +401,10 @@ class RCP_Plugin_Updater {
 				'beta'       => ! empty( $data['beta'] )
 			);
 
-			$request = wp_remote_post( $this->api_url, array( 'timeout' => 15, 'sslverify' => false, 'body' => $api_params ) );
+			$request = wp_remote_post( $this->api_url, array(
+				'timeout' => 15,
+				'body'    => $api_params
+			) );
 
 			if ( ! is_wp_error( $request ) ) {
 				$version_info = json_decode( wp_remote_retrieve_body( $request ) );

--- a/includes/admin/add-ons.php
+++ b/includes/admin/add-ons.php
@@ -89,7 +89,7 @@ function rcp_add_ons_get_feed( $tab = 'pro' ) {
 			$url = add_query_arg( array( 'display' => $tab ), $url );
 		}
 
-		$feed = wp_remote_get( esc_url_raw( $url ), array( 'sslverify' => false ) );
+		$feed = wp_remote_get( esc_url_raw( $url ) );
 
 		if ( ! is_wp_error( $feed ) ) {
 

--- a/includes/admin/class-rcp-add-on-updater.php
+++ b/includes/admin/class-rcp-add-on-updater.php
@@ -9,9 +9,9 @@
  */
 
 //set_site_transient( 'update_plugins', null );
-	
+
 class RCP_Add_On_Updater {
-	
+
 	private $api_url    = '';
 	private $api_data   = array();
 	private $addon_id   = '';
@@ -248,7 +248,10 @@ class RCP_Add_On_Updater {
 			'url'           => home_url()
 		);
 
-		$request = wp_remote_post( $this->api_url, array( 'timeout' => 15, 'sslverify' => false, 'body' => $api_params ) );
+		$request = wp_remote_post( $this->api_url, array(
+			'timeout' => 15,
+			'body'    => $api_params
+		) );
 
 		if ( ! is_wp_error( $request ) ) {
 			$request = json_decode( wp_remote_retrieve_body( $request ) );

--- a/includes/admin/settings/settings.php
+++ b/includes/admin/settings/settings.php
@@ -1781,7 +1781,10 @@ function rcp_activate_license() {
 	);
 
 	// Call the custom API.
-	$response = wp_remote_post( 'https://restrictcontentpro.com', array( 'timeout' => 15, 'sslverify' => false, 'body' => $api_params ) );
+	$response = wp_remote_post( 'https://restrictcontentpro.com', array(
+		'timeout' => 15,
+		'body'    => $api_params
+	) );
 
 	// make sure the response came back okay
 	if ( is_wp_error( $response ) )
@@ -1831,7 +1834,10 @@ function rcp_deactivate_license() {
 		);
 
 		// Call the custom API.
-		$response = wp_remote_post( 'https://restrictcontentpro.com', array( 'timeout' => 15, 'sslverify' => false, 'body' => $api_params ) );
+		$response = wp_remote_post( 'https://restrictcontentpro.com', array(
+			'timeout' => 15,
+			'body'    => $api_params
+		) );
 
 		// make sure the response came back okay
 		if ( is_wp_error( $response ) )
@@ -1882,7 +1888,10 @@ function rcp_check_license() {
 		}
 
 		// Call the custom API.
-		$response = wp_remote_post( 'https://restrictcontentpro.com', array( 'timeout' => 35, 'sslverify' => false, 'body' => $api_params ) );
+		$response = wp_remote_post( 'https://restrictcontentpro.com', array(
+			'timeout' => 35,
+			'body'    => $api_params
+		) );
 
 		// make sure the response came back okay
 		if ( is_wp_error( $response ) )

--- a/includes/gateways/class-rcp-payment-gateway-paypal-express.php
+++ b/includes/gateways/class-rcp-payment-gateway-paypal-express.php
@@ -116,7 +116,11 @@ class RCP_Payment_Gateway_PayPal_Express extends RCP_Payment_Gateway {
 			$args['PAYMENTREQUEST_0_CUSTOM'] .= '|trial';
 		}
 
-		$request = wp_remote_post( $this->api_endpoint, array( 'timeout' => 45, 'sslverify' => false, 'httpversion' => '1.1', 'body' => $args ) );
+		$request = wp_remote_post( $this->api_endpoint, array(
+			'timeout' => 45,
+			'httpversion' => '1.1',
+			'body' => $args
+		) );
 		$body    = wp_remote_retrieve_body( $request );
 		$code    = wp_remote_retrieve_response_code( $request );
 		$message = wp_remote_retrieve_response_message( $request );
@@ -228,7 +232,11 @@ class RCP_Payment_Gateway_PayPal_Express extends RCP_Payment_Gateway {
 					unset( $args['INITAMT'] );
 				}
 
-				$request = wp_remote_post( $this->api_endpoint, array( 'timeout' => 45, 'sslverify' => false, 'httpversion' => '1.1', 'body' => $args ) );
+				$request = wp_remote_post( $this->api_endpoint, array(
+					'timeout' => 45,
+					'httpversion' => '1.1',
+					'body' => $args
+				) );
 				$body    = wp_remote_retrieve_body( $request );
 				$code    = wp_remote_retrieve_response_code( $request );
 				$message = wp_remote_retrieve_response_message( $request );
@@ -296,7 +304,11 @@ class RCP_Payment_Gateway_PayPal_Express extends RCP_Payment_Gateway {
 					'BUTTONSOURCE'                   => 'EasyDigitalDownloads_SP'
 				);
 
-				$request = wp_remote_post( $this->api_endpoint, array( 'timeout' => 45, 'sslverify' => false, 'httpversion' => '1.1', 'body' => $args ) );
+				$request = wp_remote_post( $this->api_endpoint, array(
+					'timeout' => 45,
+					'httpversion' => '1.1',
+					'body' => $args
+				) );
 				$body    = wp_remote_retrieve_body( $request );
 				$code    = wp_remote_retrieve_response_code( $request );
 				$message = wp_remote_retrieve_response_message( $request );
@@ -685,7 +697,6 @@ class RCP_Payment_Gateway_PayPal_Express extends RCP_Payment_Gateway {
 
 		$request = wp_remote_post( $this->api_endpoint, array(
 			'timeout'     => 45,
-			'sslverify'   => false,
 			'httpversion' => '1.1',
 			'body'        => $args
 		) );


### PR DESCRIPTION
Removes all instances of sslverify being set to false. Because sslverify
defaults to true, we don't need to explicitly set it to true.

This commit also reformats the affected arrays to span multiple lines where
appropriate, for easier human parsing of future changes (e.g. only the affected
line gets changed if an element is added/removed, vs. the entire array
showing in the diff).

Closes #1550