### PR TITLE
Only disable WP toolbar for members (subscriber role)

### DIFF
--- a/includes/admin/settings/settings.php
+++ b/includes/admin/settings/settings.php
@@ -1585,7 +1585,7 @@ function rcp_settings_page() {
 							</th>
 							<td>
 								<input type="checkbox" value="1" name="rcp_settings[disable_toolbar]" id="rcp_settings[disable_toolbar]"<?php checked( true, isset( $rcp_options['disable_toolbar'] ) ); ?>/>
-								<span class="description"><?php _e( 'Check this if you\'d like to disable the WordPress toolbar for members. Note: will not disable the toolbar for authors, editors, or administrators.', 'rcp' ); ?></span>
+								<span class="description"><?php _e( 'Check this if you\'d like to disable the WordPress toolbar for members. Note: will not disable the toolbar for users with the edit_posts capability (e.g. authors, editors, & admins).', 'rcp' ); ?></span>
 							</td>
 						</tr>
 						<tr valign="top">

--- a/includes/admin/settings/settings.php
+++ b/includes/admin/settings/settings.php
@@ -1585,7 +1585,7 @@ function rcp_settings_page() {
 							</th>
 							<td>
 								<input type="checkbox" value="1" name="rcp_settings[disable_toolbar]" id="rcp_settings[disable_toolbar]"<?php checked( true, isset( $rcp_options['disable_toolbar'] ) ); ?>/>
-								<span class="description"><?php _e( 'Check this if you\'d like to disable the WordPress toolbar for subscribers. Note: will not disable the toolbar for administrators.', 'rcp' ); ?></span>
+								<span class="description"><?php _e( 'Check this if you\'d like to disable the WordPress toolbar for members. Note: will not disable the toolbar for authors, editors, or administrators.', 'rcp' ); ?></span>
 							</td>
 						</tr>
 						<tr valign="top">

--- a/includes/member-functions.php
+++ b/includes/member-functions.php
@@ -1318,11 +1318,7 @@ function rcp_maybe_disable_toolbar() {
 
 	global $rcp_options;
 
-	$user = wp_get_current_user();
-	$roles = ( array ) $user->roles;
-	$role = $roles[0];
-
-	if ( isset( $rcp_options['disable_toolbar'] ) && $role == 'subscriber' ) {
+	if ( isset( $rcp_options['disable_toolbar'] ) && ! current_user_can( 'edit_posts' ) ) {
 		add_filter( 'show_admin_bar', '__return_false' );
 	}
 }

--- a/includes/member-functions.php
+++ b/includes/member-functions.php
@@ -1318,7 +1318,11 @@ function rcp_maybe_disable_toolbar() {
 
 	global $rcp_options;
 
-	if ( isset( $rcp_options['disable_toolbar'] ) && ! current_user_can( 'manage_options' ) ) {
+	$user = wp_get_current_user();
+	$roles = ( array ) $user->roles;
+	$role = $roles[0];
+
+	if ( isset( $rcp_options['disable_toolbar'] ) && $role == 'subscriber' ) {
 		add_filter( 'show_admin_bar', '__return_false' );
 	}
 }


### PR DESCRIPTION
Also improves wording on settings page.

Closes #1729