### PR TITLE
Only display payment date on invoices if paid

### DIFF
--- a/templates/invoice.php
+++ b/templates/invoice.php
@@ -298,9 +298,11 @@ global $rcp_options, $rcp_payment, $rcp_member; ?>
 			<div class="alignleft">
 				<header><?php _e( 'Additional Info:', 'rcp' ); ?></header>
 
-				<article>
-					<p><?php echo __( 'Payment Date:', 'rcp' ) . ' ' . date_i18n( get_option( 'date_format' ), strtotime( $rcp_payment->date, current_time( 'timestamp' ) ) ); ?></p>
-				</article>
+				<?php if ( in_array( $rcp_payment->status, array( 'complete', 'refunded' ) ) ) : ?>
+					<article>
+						<p><?php echo __( 'Payment Date:', 'rcp' ) . ' ' . date_i18n( get_option( 'date_format' ), strtotime( $rcp_payment->date, current_time( 'timestamp' ) ) ); ?></p>
+					</article>
+				<?php endif; ?>
 
 				<?php if( ! empty( $rcp_options['invoice_notes'] ) ) : ?>
 					<article>


### PR DESCRIPTION
For statuses of `complete` and `refunded`, a payment date is displayed.

For `pending`, `failed`, and `abandoned` a payment date is not shown

Closes #1668 