### PR TITLE
Adjust Google Auth footer hook to fix strict standards warning. #1797

### DIFF
--- a/includes/integrations/class-rcp-google-authenticator.php
+++ b/includes/integrations/class-rcp-google-authenticator.php
@@ -23,8 +23,10 @@ class RCP_Google_Authenticator {
 			return;
 		}
 
+		$google_auth = new GoogleAuthenticator;
+
 		add_action( 'rcp_login_form_fields_before_submit', array( $this, 'auth_code_input' ) );
-		add_action( 'rcp_after_login_form_fields', array( 'GoogleAuthenticator', 'loginfooter' ) );
+		add_action( 'rcp_after_login_form_fields', array( $google_auth, 'loginfooter' ) );
 		add_action( 'rcp_login_form_errors', array( $this, 'check_code' ) );
 	}
 


### PR DESCRIPTION
Closes #1797