### PR TITLE
Replace tilde with caret in Composer installers requirement

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,6 +12,6 @@
 		}
 	],
 	"require": {
-		"composer/installers": "~1.0.6"
+		"composer/installers": "^1.0.6"
 	}
 }


### PR DESCRIPTION
This updates `composer.json` to require `^1.0.6` instead of `~1.0.6`.

Technically speaking, this just means Composer will allow resolving the `composer/installers` package to any version greater than or equal to `1.0.6` and less than `2.0.0`.

The tilde would only allow greater than or equal to `1.0.6` and less than `1.1.0`.

This makes RCP possible to install in any environments that use more recent versions of `composer/installers` (it's on `1.5.0` at the moment).

Fixes #1834.