### PR TITLE
Add timestamp to the system info

### DIFF
--- a/includes/admin/tools/system-info.php
+++ b/includes/admin/tools/system-info.php
@@ -349,7 +349,10 @@ function rcp_tools_system_info_report() {
 
 	$return = apply_filters( 'rcp_system_info_after_php_extensions', $return );
 
-	$return .= "\n" . '### End System Info ###';
+	$return .= "\n" . '-- Miscellaneous' . "\n\n";
+	$return .= 'System Info Generated:    ' . date( 'Y-m-d H:i:s', current_time( 'timestamp' ) );
+
+	$return .= "\n\n" . '### End System Info ###';
 
 	return $return;
 }

--- a/includes/admin/tools/system-info.php
+++ b/includes/admin/tools/system-info.php
@@ -350,7 +350,7 @@ function rcp_tools_system_info_report() {
 	$return = apply_filters( 'rcp_system_info_after_php_extensions', $return );
 
 	$return .= "\n" . '-- Miscellaneous' . "\n\n";
-	$return .= 'System Info Generated:    ' . date( 'Y-m-d H:i:s', current_time( 'timestamp' ) );
+	$return .= 'System Info Generated:    ' . current_time( 'mysql', true ) . ' (GMT)';
 
 	$return .= "\n\n" . '### End System Info ###';
 


### PR DESCRIPTION
Fixes #1862 by adding a timestamp at the bottom of the system info file with the date/time the file is generated.

![tools_ _mindful_ _wordpress](https://user-images.githubusercontent.com/1231306/43230672-372c3e20-9037-11e8-940a-e1e80fb91c06.png)

(Note that this info is also available in the date/time format setting under the "WordPress Configuration" section as well, but I think it's nice to have at the bottom too!)